### PR TITLE
docs: sync skills with asc 4.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Guidance for running `asc` commands (canonical verbs, flags, pagination, output,
 **Use when:**
 - You need the correct `asc` command or flag combination
 - You want JSON-first output and pagination tips for automation
-- You need Apple Ads command, auth, org, payload, or pagination guidance
+- You need Apple Ads command, auth, ad-account, org, payload, or pagination guidance
 
 **Example:**
 
@@ -58,17 +58,18 @@ Find the right asc command to list all builds for app 123456789 as JSON and pagi
 
 ### asc-apple-ads
 
-Apple Ads auth, org lookup, campaigns, ad groups, ads, keywords, reports, raw API calls, and safe live testing.
+Apple Ads auth and account discovery, Platform API v1 campaigns, targeting, reports, assets, guarded mutations, raw calls, and v5 migration.
 
 **Use when:**
 - You need to read or change Apple Ads resources with `asc ads`
-- You need Apple Ads OAuth, profile, or `ASC_ADS_*` guidance
+- You need Apple Ads OAuth, profile, ad-account context, or `ASC_ADS_*` guidance
 - You need a safe read-first plan before mutating a live Ads account
+- You need to migrate deprecated `asc ads v5` automation to Platform API v1
 
 **Example:**
 
 ```bash
-Find my Apple Ads org, list campaigns as JSON, and draft a safe plan before creating any test campaign.
+Discover my Apple Ads ad account, query campaigns through Platform API v1, and draft a paused test plan before creating anything.
 ```
 
 ### asc-workflow
@@ -132,6 +133,21 @@ the experimental `asc distribute` workflow.
 
 ```bash
 Plan a private release-testing install from this Xcode archive, show me the exact effects, and apply only after I approve the plan hash.
+```
+
+### asc-screenshot-resize
+
+Resize and validate App Store screenshots using the current size catalog from `asc screenshots sizes` and macOS `sips`.
+
+**Use when:**
+- You need to inspect the screenshot dimensions Apple currently accepts
+- You need to remove alpha or resize screenshots before upload
+- You want local validation against an App Store screenshot device type
+
+**Example:**
+
+```bash
+Validate these iPhone screenshots, resize only the invalid files, and verify the results before upload.
 ```
 
 ### asc-shots-pipeline

--- a/skills/asc-apple-ads/SKILL.md
+++ b/skills/asc-apple-ads/SKILL.md
@@ -1,23 +1,23 @@
 ---
 name: asc-apple-ads
-description: Use when managing Apple Ads with asc, including auth, org lookup, campaigns, ad groups, ads, keywords, reports, raw API calls, and safe live testing.
+description: Use when managing Apple Ads with asc, including OAuth profiles, ad-account discovery, Platform API v1 campaigns and targeting, reports, assets, recommendations, guarded mutations, raw requests, and Campaign Management API v5 migration.
 ---
 
 # asc Apple Ads
 
-Use this skill when a task involves Apple Ads or `asc ads`.
+Run Apple Ads work through `asc ads`. Apple Ads credentials are separate from App Store Connect credentials; `asc auth login` does not configure Ads.
 
-## Ground Rules
-- Run `asc ads --help` or the specific subgroup help before scripting a command.
-- Apple Ads auth is separate from App Store Connect auth. `asc auth login` does not configure `asc ads`.
-- Use JSON output for automation: `--output json`.
-- Most commands need an org ID. Prefer `--org` for one-off commands and `ASC_ADS_ORG_ID` for a scoped session.
-- Never guess payload fields. Use Apple Ads request JSON in a file and pass it with `--file`.
-- Do not mutate a live account until the user has named the org and approved the resource type. Prefer read-only checks first.
+## Pick the API first
 
-## Auth
+- Direct `asc ads <resource> ...` commands use Apple Ads Platform API v1 and an ad account ID.
+- Deprecated Campaign Management API v5 commands live under `asc ads v5 ...` and use an organization ID. Apple retires v5 on January 26, 2027.
+- Never substitute an org ID for an ad account ID. The CLI keeps them separate.
+- Run the exact leaf command with `--help` before building a request file. Platform v1 payloads and response envelopes differ from v5; the CLI does not translate them.
+- Resource, report, upload, and raw commands emit lossless JSON. Use `jq` for projections instead of asking for table or markdown output.
 
-Stored profile:
+## Authenticate and pin the account
+
+Store both contexts when a profile must support v1 and legacy v5:
 
 ```bash
 asc ads auth login \
@@ -26,139 +26,239 @@ asc ads auth login \
   --team-id "$ASC_ADS_TEAM_ID" \
   --key-id "$ASC_ADS_KEY_ID" \
   --private-key "$ASC_ADS_PRIVATE_KEY_PATH" \
-  --org "$ASC_ADS_ORG_ID" \
+  --ad-account "987654" \
+  --org "123456" \
   --network
 ```
 
-Environment auth:
+For CI, set Ads-specific variables and bypass the host keychain:
 
 ```bash
 export ASC_ADS_CLIENT_ID="SEARCHADS_CLIENT_ID"
 export ASC_ADS_TEAM_ID="SEARCHADS_TEAM_ID"
 export ASC_ADS_KEY_ID="KEY_ID"
 export ASC_ADS_PRIVATE_KEY_PATH="$HOME/.asc/apple-ads-private-key.pem"
-export ASC_ADS_ORG_ID="123456"
+export ASC_ADS_AD_ACCOUNT_ID="987654"
+export ASC_ADS_BYPASS_KEYCHAIN=1
 ```
 
-Short-lived token auth:
+`ASC_ADS_PRIVATE_KEY` and `ASC_ADS_PRIVATE_KEY_B64` also work. If another trusted process minted a short-lived token, set `ASC_ADS_ACCESS_TOKEN`; scoped v1 calls still need an ad account ID.
 
-```bash
-export ASC_ADS_ACCESS_TOKEN="ACCESS_TOKEN"
-export ASC_ADS_ORG_ID="123456"
-```
-
-Useful checks:
+Check auth without printing a token:
 
 ```bash
 asc ads auth status --validate --output json
+asc ads auth discover --ads-profile "Marketing" --output json
 asc ads auth doctor --output json
-asc ads me view --output json
-asc ads acls --output json
 ```
 
-## Org Resolution
+Discovery calls Platform v1 `GET /v1/me` and `GET /v1/acls`. Compare each ACL's ad-account ID, name, organization ID, and roles; never select the first result automatically. Print the chosen account before any mutation, then pass both `--ads-profile "Marketing"` and `--ad-account "987654"` when more than one profile or account is available.
 
-When the org ID is unknown:
+For named profiles, the profile's `ad_account_id` and `org_id` stand alone; they do not inherit context from another profile or root config. V1 context precedence is `--ad-account`, `ASC_ADS_AD_ACCOUNT_ID`, the selected profile, then profile-less root config. Legacy v5 uses the matching `--org` and `ASC_ADS_ORG_ID` chain.
+
+## Start read-only
+
+Identity and ACL calls need no ad account context:
 
 ```bash
-asc ads acls --output json
+asc ads me view --ads-profile "Marketing" --output json
+asc ads acls list --ads-profile "Marketing" --output json
+asc ads orgs view --ads-profile "Marketing" --org-id "123456" --output json
 ```
 
-Use the returned org ID:
+Then prove the selected account with a small app search:
 
 ```bash
-asc ads campaigns --org "123456" --limit 10 --output json
-```
-
-Org precedence is `--org`, `ASC_ADS_ORG_ID`, stored profile `org_id`, then config `ads.org_id`.
-
-## Read Workflows
-
-Campaigns and ad groups:
-
-```bash
-asc ads campaigns --org "123456" --limit 100 --output json
-asc ads campaigns --org "123456" --paginate --output json
-asc ads campaigns view --org "123456" --campaign 987654321 --output json
-asc ads ad-groups list --org "123456" --campaign 987654321 --output json
-```
-
-Discovery:
-
-```bash
-asc ads apps search --org "123456" --query "My App" --limit 10 --output json
-asc ads product-pages list --org "123456" --adam-id 1234567890 --states VISIBLE --output json
-asc ads creatives list --org "123456" --limit 100 --output json
-asc ads geo search --org "123456" --query "San Francisco" --country-code US --limit 10 --output json
-```
-
-Reports:
-
-```bash
-asc ads reports campaigns --org "123456" --file reporting-request.json --output json
-asc ads reports keywords --org "123456" --campaign 987654321 --file reporting-request.json --output json
-```
-
-Reporting and find endpoints keep pagination in the JSON body.
-
-## Mutating Workflows
-
-Create and update commands take Apple Ads JSON files:
-
-```bash
-asc ads campaigns create --org "123456" --file campaign.json --output json
-asc ads campaigns update --org "123456" --campaign 987654321 --file campaign-update.json --output json
-asc ads ad-groups create --org "123456" --campaign 987654321 --file ad-group.json --output json
-```
-
-Bulk endpoints often require arrays:
-
-```bash
-asc ads targeting-keywords create-bulk \
-  --org "123456" \
-  --campaign 987654321 \
-  --ad-group 123456789 \
-  --file keywords.json \
+asc ads apps search \
+  --ads-profile "Marketing" \
+  --ad-account "987654" \
+  --query "Example" \
+  --limit 1 \
   --output json
 ```
 
-Delete commands require `--confirm`:
+App search requires at least one of `--query`, `--cpids`, or `--return-owned-apps`. Storefronts use comma-separated ISO alpha-2 codes. Add `--paginate` only when every search result is needed.
 
-```bash
-asc ads targeting-keywords delete-bulk \
-  --org "123456" \
-  --campaign 987654321 \
-  --ad-group 123456789 \
-  --file keyword-ids.json \
-  --confirm \
-  --output json
+Use each resource's `find` command for inventory. Most v1 queries put filters, sorting, and pagination in a JSON object. A subordinate-resource filter looks like this:
 
-asc ads campaigns delete --org "123456" --campaign 987654321 --confirm
+```json
+{
+  "filters": [
+    {"field": "campaignId", "operator": "EQUALS", "value": ["campaign-id"]}
+  ],
+  "pagination": {"offset": 0, "pageSize": 100, "fetchTotalCount": true}
+}
 ```
 
-For live tests, create paused resources with names such as `ASC CLI Live Test <timestamp>`. Clean up only the parent campaign or ad group created for that test. Apple may reject direct deletion for default product page creative ads, but deleting the test parent campaign or ad group can clean up the test resource.
+```bash
+asc ads campaigns find --ads-profile "Marketing" --ad-account "987654" --output json
+asc ads ad-groups find --ads-profile "Marketing" --ad-account "987654" --file query.json --output json
+asc ads ads find --ads-profile "Marketing" --ad-account "987654" --file query.json --output json
+```
 
-## Raw API
+Omitting `--file` from `campaigns find` requests the default first page. To control or exhaust the result set, use `pagination.offset`, `pageSize`, and `fetchTotalCount` in a query file, read the response pagination, and advance the offset until complete. This command has no `--paginate` flag. Platform filters use the singular `value`; do not copy v5 `Selector` fields such as `conditions` or plural `values`, which current `asc` rejects before auth.
 
-Use raw requests when Apple adds a field before the first-class command surface changes:
+The direct v1 tree also covers ad accounts and advertiser resources; app eligibility, locales, product pages, and rejection reasons; brands, business categories, locations, location groups, creatives, and assets; geographic targeting and shared budgets; reports for apps and brands; insights, suggestions, recommendations, and change history. Discover the exact leaf instead of falling back to raw HTTP:
+
+```bash
+asc ads change-history --help
+asc ads suggestions --help
+asc ads rejection-reasons --help
+asc ads reports brands --help
+```
+
+Keyword queries need a selector file. Targeting keywords require an `id`, `adGroupId`, or `campaignId` filter. Negative keywords require `id` or `adGroupId`; campaign-level negative keywords combine `campaignId` with an `adGroupId` filter whose operator is `IS_NULL`.
+
+```bash
+asc ads targeting-keywords find --ads-profile "Marketing" --ad-account "987654" --file keyword-query.json --output json
+asc ads negative-keywords find --ads-profile "Marketing" --ad-account "987654" --file negative-keyword-query.json --output json
+```
+
+## Reports and optimization
+
+V1 reports require an endpoint-specific body. Dates live under `timeRange`, page controls use `offset` and `pageSize`, and campaign or ad-group IDs belong in `filters`:
+
+```json
+{
+  "pagination": {"offset": 0, "pageSize": 20},
+  "filters": [
+    {"field": "campaignId", "operator": "EQUALS", "value": ["campaign-id"]}
+  ],
+  "groupBy": ["countryOrRegion"],
+  "timeRange": {
+    "start": "2026-08-01",
+    "end": "2026-08-14",
+    "timeZone": "ORTZ",
+    "granularity": "DAILY"
+  }
+}
+```
+
+```bash
+asc ads reports apps campaigns \
+  --ads-profile "Marketing" \
+  --ad-account "987654" \
+  --file report.json \
+  --output json
+```
+
+Report commands do not accept `--paginate`; change pagination in the body. Inspect the leaf help because report entities accept different `groupBy` and option values.
+
+Recommendations and suggestions also use endpoint-specific bodies. Applying or dismissing recommendations can change spend and requires `--confirm`:
+
+```bash
+asc ads recommendations daily-budgets find --ads-profile "Marketing" --ad-account "987654" --file query.json
+asc ads recommendations daily-budgets apply --ads-profile "Marketing" --ad-account "987654" --file recommendations.json --confirm
+```
+
+## Guard mutations
+
+Do not mutate until the user has approved the ad account, resource type, target IDs, and reviewed payload. Keep request JSON in files; never invent fields from a related v5 schema.
+
+Campaign creation may start spending. `CampaignCreate` requires `adAccountId`, `billingEvent`, `dailyBudget`, `name`, `promotedObjectId`, `promotedObjectType`, and `targeting`. The CLI sends the file unchanged: `--ad-account` selects the request context but does not inject `adAccountId` into the JSON. Start from this paused shape, replace every placeholder with values read from the selected account, and recheck the current Apple v1 schema for any account-specific requirements:
+
+```json
+{
+  "name": "ASC agent validation 2026-08-15T00:00:00Z",
+  "status": "PAUSED",
+  "adAccountId": 987654,
+  "promotedObjectType": "APPSTORE_APP",
+  "promotedObjectId": "123456789",
+  "billingEvent": "TAPS",
+  "dailyBudget": {"value": {"amount": "1", "currency": "USD"}},
+  "startTime": "2030-01-01T00:00:00.000",
+  "endTime": "2030-01-02T00:00:00.000",
+  "targeting": {"countryOrRegion": {"include": ["US"]}},
+  "bidStrategy": {"bidStrategyType": "MANUAL_CPT", "bidStrategyGoal": "TAP"}
+}
+```
+
+A payload with explicit top-level `"status":"PAUSED"` can run without `--confirm`; an omitted or non-paused status requires it.
+
+```bash
+asc ads campaigns create --ads-profile "Marketing" --ad-account "987654" --file paused-campaign.json
+asc ads campaigns pause --ads-profile "Marketing" --ad-account "987654" --campaign "campaign-id"
+asc ads campaigns resume --ads-profile "Marketing" --ad-account "987654" --campaign "campaign-id" --confirm
+```
+
+Campaign updates need `--confirm` when they can change budget, targeting, bids, delivery, dates, or status. A name-only update or a name plus `PAUSED` status does not. Deletes, bulk creates or updates, recommendation apply or dismiss calls, budget-order writes, and other operationally risky mutations require confirmation before auth or network access.
+
+Ad-group creation and keyword bulk writes are examples of always-confirmed delivery or targeting changes. V1 bulk keyword files use wrapper objects such as `KeywordCreateBulkRequest`, not the v5 raw-array shape:
+
+```bash
+asc ads ad-groups create --ads-profile "Marketing" --ad-account "987654" --file ad-group.json --confirm
+asc ads targeting-keywords create-bulk --ads-profile "Marketing" --ad-account "987654" --file keywords.json --confirm
+asc ads targeting-keywords delete --ads-profile "Marketing" --ad-account "987654" --keyword "keyword-id" --confirm
+```
+
+Shared budgets use the `budget-orders` command group. Create, update, and delete are context-free but require confirmation; view and find accept optional ad-account context.
+
+```bash
+asc ads budget-orders create --ads-profile "Marketing" --file shared-budget.json --confirm
+asc ads budget-orders update --ads-profile "Marketing" --budget-order "budget-id" --file update.json --confirm
+asc ads budget-orders delete --ads-profile "Marketing" --budget-order "budget-id" --confirm
+```
+
+Ad-account creation also requires `--confirm` because its account family cannot change and Apple provides no delete endpoint. An ad-account update containing `delegations` requires confirmation because it replaces the complete list.
+
+Use the dedicated multipart command for brand assets. Poll until Apple finishes processing:
+
+```bash
+asc ads assets upload --ads-profile "Marketing" --file ./brand.png --brand "BRAND_ID" --ad-account "987654"
+asc ads assets view --ads-profile "Marketing" --asset "ASSET_UUID" --ad-account "987654"
+```
+
+Only use an asset when `eligibility.status` is `ELIGIBLE`; for `LIMITED`, inspect `allowedGroups`. Do not attach `PENDING` or `INELIGIBLE` assets.
+
+## Raw requests
+
+Use first-class commands for routine work. Raw v1 requests accept only `v1/...` paths or `https://api.ads.apple.com/v1/...` URLs:
 
 ```bash
 asc ads api request \
   --method POST \
+  --path v1/campaigns/query \
+  --ads-profile "Marketing" \
+  --ad-account "987654" \
+  --file query.json \
+  --output json
+```
+
+Unknown mutations fail closed, and risky known mutations require `--confirm`. The raw command rejects multipart asset upload; use `asc ads assets upload`.
+
+Keep legacy calls explicit:
+
+```bash
+asc ads v5 api request \
+  --method POST \
   --path v5/campaigns/find \
+  --ads-profile "Marketing" \
   --org "123456" \
   --file selector.json \
   --output json
 ```
 
-Raw requests accept only Apple Ads v5 paths or `https://api.searchads.apple.com/api/v5/...` URLs. `DELETE` still requires `--confirm`.
+## Migrate v5 one command at a time
 
-## Live Test Checklist
+Keep existing v5 payloads under `asc ads v5` until each script has a reviewed v1 body and response parser. Common moves:
 
-- Start with `asc ads me view --output json` and `asc ads acls --output json`.
-- Print the target org ID before mutations.
-- Create paused or future-dated resources.
-- Use a unique test name.
-- Save created IDs from JSON output.
-- Delete only the test parent campaign or ad group created during the run.
-- Run a final campaigns find/list query to confirm cleanup.
+| Deprecated v5 | Platform API v1 |
+| --- | --- |
+| `asc ads v5 campaigns list` | `asc ads campaigns find` |
+| `asc ads v5 apps localized-details` | `asc ads apps locales find` |
+| `asc ads v5 product-pages list` | `asc ads product-pages find` |
+| `asc ads v5 reports campaigns` | `asc ads reports apps campaigns` |
+| `asc ads v5 campaigns pause` / `resume` | `asc ads campaigns pause` / `resume` |
+| v5 campaign or ad-group negative keywords | `asc ads negative-keywords ...` with scope in the body |
+
+Seven v5 leaves have no one-command v1 replacement: product-page countries, product-page devices, targeting-keyword bulk delete, both negative-keyword bulk deletes, and impression-share report list and view. Do not pretend that `geo search`, `insights impression-share`, or single-resource deletes preserve those contracts.
+
+## Finish live tests cleanly
+
+- Start with ACL discovery and a one-result app search.
+- Use a unique timestamped name and explicit `PAUSED` status for disposable campaign tests.
+- Save every created ID from JSON output.
+- Pause spend-bearing resources before checking anything else.
+- Reread a test campaign with `asc ads campaigns view --ads-profile "Marketing" --ad-account "987654" --campaign "campaign-id" --output json`.
+- Delete only test-created campaigns with `asc ads campaigns delete --ads-profile "Marketing" --ad-account "987654" --campaign "campaign-id" --confirm`; do not delete a pre-existing parent.
+- Run the same `campaigns view` again. Treat Apple's not-found response as cleanup proof; report any campaign that still exists or could not be removed.

--- a/skills/asc-cli-usage/SKILL.md
+++ b/skills/asc-cli-usage/SKILL.md
@@ -63,12 +63,12 @@ Use this skill when you need to run or design `asc` commands for App Store Conne
 ## Apple Ads
 - Use `asc ads --help` before choosing a command.
 - Apple Ads uses `asc ads auth`, `--ads-profile`, and `ASC_ADS_*` variables. It does not use App Store Connect API credentials.
-- Resolve org access with `asc ads acls --output json` unless the org ID is already known.
-- Most endpoint commands need `--org` or `ASC_ADS_ORG_ID`.
-- Body commands use `--file` with Apple Ads JSON payloads. Object endpoints need a JSON object. Bulk endpoints often need a JSON array.
-- Use `--paginate` only where help shows it. Reporting and selector payloads carry pagination inside the JSON file.
-- Destructive commands and bulk delete commands require `--confirm`.
-- For live mutation tests, create paused resources with a clear test name and delete the parent campaign when done.
+- Direct resource commands use Platform API v1 with `--ad-account` or `ASC_ADS_AD_ACCOUNT_ID`. Deprecated Campaign Management API v5 commands live under `asc ads v5` and use `--org` or `ASC_ADS_ORG_ID`; never substitute one ID for the other.
+- Discover ad-account access with `asc ads auth discover --output json` or inspect one ACL response with `asc ads acls list --output json`.
+- Body commands use `--file` with the exact schema named by the leaf help. V1 query filters use singular `value`, and bulk bodies may use wrapper objects rather than v5 arrays.
+- Apple Ads resource commands emit JSON. Use `--paginate` only where help shows it; reports and most query bodies carry pagination inside the JSON file.
+- Deletes and spend-, billing-, delivery-, targeting-, or access-sensitive mutations require `--confirm`. An explicitly paused campaign create is the main documented safe exception.
+- For live mutation tests, create paused resources with a clear test name, save every ID, pause spend-bearing resources first, and delete only resources created by the test.
 
 ## Timeouts
 - `ASC_TIMEOUT` / `ASC_TIMEOUT_SECONDS` control request timeouts.

--- a/skills/asc-localize-metadata/SKILL.md
+++ b/skills/asc-localize-metadata/SKILL.md
@@ -15,7 +15,7 @@ Use this skill to pull English (or any source locale) App Store metadata, transl
   - `asc localizations upload --help`
   - `asc apps info edit --help`
 - Prefer explicit long flags (`--app`, `--version`, `--version-id`, `--type`, `--app-info`).
-- Default output is JSON; use `--output table` only for human verification steps.
+- Output defaults are TTY-aware: table in interactive terminals and JSON in CI or other non-interactive contexts. Use explicit `--output` when the format matters.
 - Prefer deterministic ID-based operations. Do not "pick the first row" via `head -1` unless the user explicitly agrees.
 
 ## Preconditions
@@ -27,10 +27,11 @@ Use this skill to pull English (or any source locale) App Store metadata, transl
 
 App Store Connect locales for version and app-info localizations:
 ```
-ar-SA, ca, cs, da, de-DE, el, en-AU, en-CA, en-GB, en-US,
-es-ES, es-MX, fi, fr-CA, fr-FR, he, hi, hr, hu, id, it,
-ja, ko, ms, nl-NL, no, pl, pt-BR, pt-PT, ro, ru, sk,
-sv, th, tr, uk, vi, zh-Hans, zh-Hant
+ar-SA, bn-BD, ca, cs, da, de-DE, el, en-AU, en-CA, en-GB,
+en-US, es-ES, es-MX, fi, fr-CA, fr-FR, gu-IN, he, hi, hr,
+hu, id, it, ja, kn-IN, ko, ml-IN, mr-IN, ms, nl-NL, no,
+or-IN, pa-IN, pl, pt-BR, pt-PT, ro, ru, sk, sl-SI, sv,
+ta-IN, te-IN, th, tr, uk, ur-PK, vi, zh-Hans, zh-Hant
 ```
 
 ## Two Types of Metadata

--- a/skills/asc-metadata-sync/SKILL.md
+++ b/skills/asc-metadata-sync/SKILL.md
@@ -77,7 +77,7 @@ asc metadata status --review-dir ".asc/metadata/review" --output table
 asc metadata apply --app "APP_ID" --version "1.2.3" --platform IOS --dir "./metadata" --review-dir ".asc/metadata/review" --confirm
 ```
 
-Use `asc metadata approve --key "version:en-US:whatsNew"` or `--scope app-info,version` when the user wants selective approval artifacts before the guarded apply.
+Use `asc metadata approve --key "version:1.2.3:en-US:whatsNew"` or `--scope app-info,version` when the user wants selective approval artifacts before the guarded apply. Version-scoped keys include the App Store version string.
 
 ## Keyword-only workflow
 

--- a/skills/asc-ppp-pricing/SKILL.md
+++ b/skills/asc-ppp-pricing/SKILL.md
@@ -190,7 +190,7 @@ verification enabled to recheck the parent, pricing, screenshot, and
 availability state.
 
 ### Subscription availability
-If you need to explicitly enable territories for an existing subscription, use the pricing availability family.
+The underlying subscription-availability resource is deprecated in App Store Connect API 4.4. Keep this command family only for compatibility when ordinary upfront territory availability still needs it; Apple does not provide a one-for-one replacement for that case. For Monthly with 12-Month Commitment, use `asc subscriptions pricing monthly-commitment enable|disable|list` instead.
 
 ```bash
 asc subscriptions pricing availability edit --subscription-id "SUB_ID" --territories "USA,CAN,IND,BRA"


### PR DESCRIPTION
## Summary

Sync the workflow skills against App-Store-Connect-CLI main at `0bf709308a386c14c9d4754ed26d6c28597d9555` (`4.4.0-7-g0bf709308`). The skills baseline is `f1867adbf424dc83bef2d1d4dd5973ddc4876047`.

- Rewrite `asc-apple-ads` for the direct Platform API v1 command tree, distinct ad-account context, deprecated `asc ads v5` migration, guarded mutations, reports, assets, and deterministic cleanup.
- Update shared Apple Ads guidance and subscription-availability compatibility notes.
- Correct version-scoped metadata approval keys and the TTY-aware output contract.
- Refresh the supported App Store locale catalog to all 50 current values.
- Restore the missing `asc-screenshot-resize` README inventory entry.

## Validation

- Parsed every changed Apple Ads command path and flag with the binary built from exact CLI main.
- Ran the skill-creator quick validator on every changed skill.
- Ran `agentskills validate` from `skills-ref==0.1.1` for all 25 skills.
- Ran `python3 -m unittest discover -s tests -v`.
- Ran `python3 scripts/validate-plugin-packaging.py`.
- Verified README inventory count matches the 25 skill directories.
- Ran `git diff --check`.

No live Apple Ads requests or account mutations were made.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated Apple Ads guidance for Platform API v1, account discovery, read-only workflows, guarded mutations, asset uploads, and migration from API v5.
  - Clarified command formats, output behavior, pagination, confirmations, and cleanup procedures.
  - Added guidance for validating and resizing App Store screenshots.
  - Documented TTY-aware output defaults and expanded locale support.
  - Improved metadata approval examples and clarified deprecated subscription pricing resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->