### PR TITLE
docs: document Ads stdin payloads

### DIFF
--- a/skills/asc-apple-ads/SKILL.md
+++ b/skills/asc-apple-ads/SKILL.md
@@ -13,6 +13,7 @@ Run Apple Ads work through `asc ads`. Apple Ads credentials are separate from Ap
 - Deprecated Campaign Management API v5 commands live under `asc ads v5 ...` and use an organization ID. Apple retires v5 on January 26, 2027.
 - Never substitute an org ID for an ad account ID. The CLI keeps them separate.
 - Run the exact leaf command with `--help` before building a request file. Platform v1 payloads and response envelopes differ from v5; the CLI does not translate them.
+- For non-interactive pipelines, pass `--file -` to read a JSON request body from stdin; the CLI rejects it when stdin is a terminal.
 - Resource, report, upload, and raw commands emit lossless JSON. Use `jq` for projections instead of asking for table or markdown output.
 
 ## Authenticate and pin the account


### PR DESCRIPTION
## Summary

Document non-interactive Apple Ads JSON payload input with `--file -`.

## CLI evidence

ASC CLI 4.4.3 (`f7de58a`) shows `--file` as `Path to Apple Ads JSON payload ('-' reads stdin)` for both `asc ads campaigns find --help` and `asc ads reports apps campaigns --help`. A piped JSON payload reaches credential resolution, confirming stdin input is accepted before auth.

## Validation

- `go test ./internal/cli/shared`
- `python -m unittest discover -s tests -v`
- `python scripts/validate-plugin-packaging.py . --expected-skills 25`
- `agentskills validate` for all 25 skills (`skills-ref==0.1.1`)
- `claude plugin validate .claude-plugin/plugin.json --strict`
- `claude plugin validate .claude-plugin/marketplace.json --strict`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for non-interactive Apple Ads workflows to provide JSON request bodies through standard input.
  * Clarified that this input method is rejected when standard input is connected to a terminal.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->