### PR TITLE
docs: add official search plan to ASO skill

### DIFF
--- a/skills/asc-aso-audit/SKILL.md
+++ b/skills/asc-aso-audit/SKILL.md
@@ -64,6 +64,33 @@ Use tags as context only:
 - If tags point to an unintended category or use case, recommend metadata/category changes that may improve future classification.
 - Do not promise that changing metadata will immediately change Apple-generated tags.
 
+### Optional: Official Apple Search Plan
+
+When both App Store Connect and Apple Ads credentials are configured, use the
+experimental, read-only plan to join the selected metadata with official paid
+search evidence:
+
+```bash
+asc optimize search plan \
+  --app "APP_ID" \
+  --version "1.2.3" \
+  --ad-account "AD_ACCOUNT_ID" \
+  --country "US" \
+  --genre "PRODUCTIVITY_UTILITIES" \
+  --locale "en-US" \
+  --out-dir ".asc/optimization/1.2.3" \
+  --output markdown
+```
+
+- Authenticate App Store Connect with `asc auth` and Apple Ads separately with
+  `asc ads auth login`; the two credential sets are independent.
+- Treat the generated CSV and JSON files as review artifacts. The command does
+  not apply metadata, exact keywords, or negative keywords, and partial Apple
+  Ads source failures stay visible in the report.
+- Keep Apple's popularity, app-specific paid reach, paid search outcomes, and
+  metadata coverage distinct. Do not infer organic rank or keyword difficulty
+  from this plan.
+
 ### 2. Underutilized Fields
 
 Flag fields using less than their recommended minimum:


### PR DESCRIPTION
## Evidence

ASC CLI release `4.4.4` (`eb5ccfe4`) adds `asc optimize search plan`, an experimental read-only workflow that joins official Apple Ads Platform API v1 data with App Store Connect metadata.

Validated with the release binary:

```console
asc optimize --help
asc optimize search --help
asc optimize search plan --help
```

The command requires `--app`, `--version`, `--ad-account`, `--country`, `--genre`, and `--locale`; `--out-dir` writes review artifacts and `--output markdown` is supported. It does not mutate metadata or campaigns.

## Change

Adds a concise optional section to `asc-aso-audit` with an exact command example, separate ASC/Ads authentication requirement, and review-only output guidance.

## Validation

```console
python3 scripts/validate-plugin-packaging.py
python3 -m unittest tests/test_validate_plugin_packaging.py
```

Both passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for an optional Apple Search Plan workflow.
  * Documented required credentials, generated outputs, and visibility into partial failures.
  * Clarified the differences between paid-search metrics, metadata coverage, organic ranking, and keyword difficulty.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->