### PR TITLE
docs: correct build upload workflow

### DIFF
--- a/skills/asc-build-lifecycle/SKILL.md
+++ b/skills/asc-build-lifecycle/SKILL.md
@@ -33,5 +33,6 @@ Use this skill to manage build state, processing, and retention.
   - `asc builds expire --build-id "BUILD_ID" --confirm`
 
 ## Notes
-- `asc builds upload` prepares upload operations only; use `asc publish` for end-to-end flows.
+- `asc builds upload` uploads and commits an IPA or PKG. Use `asc publish` when
+  the workflow must also distribute to TestFlight or stage an App Store release.
 - For long processing times, use `--wait`, `--poll-interval`, and `--timeout` where supported.


### PR DESCRIPTION
## Evidence

Verified with App Store Connect CLI `4.6.0` (`85af115db`): `asc builds upload --help` says the command uploads an IPA/PKG and commits it immediately; `--dry-run` is the option that only reserves operations.

The build-lifecycle skill previously stated that `asc builds upload` only prepared upload operations. This corrects that statement while retaining `asc publish` as the path for workflows that also distribute or stage a release.

## Validation

- `make build` for ASC CLI `4.6.0`
- `asc builds upload --help`
- `python3 scripts/validate-plugin-packaging.py . --expected-skills 25`
- `python3 -m unittest discover -s tests -p 'test_*.py'`\n\nThe local skill-creator quick validator could not run because its Python runtime lacks PyYAML (`ModuleNotFoundError: yaml`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that `asc builds upload` uploads and commits IPA or PKG files.
  * Added guidance to use `asc publish` for distribution and App Store staging workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->