### PR TITLE
Clarify approval reuse and continuation in ASC workflows

### DIFF
--- a/skills/asc-aso-audit/SKILL.md
+++ b/skills/asc-aso-audit/SKILL.md
@@ -166,7 +166,7 @@ If Astro MCP is available and the app is tracked, run keyword gap analysis. **Ru
 
 1. **Get current keywords**: Call `get_app_keywords` with the app ID to retrieve tracked keywords and their current rankings.
 
-2. **Ensure multi-store tracking**: For each locale with a corresponding App Store territory (e.g., `ar-SA` → Saudi Arabia, `fr-FR` → France, `tr` → Turkey), use `add_keywords` to add keyword tracking in that store. Without this, `search_rankings` returns empty for non-US stores.
+2. **Check multi-store tracking**: Query existing tracking for each locale's App Store territory. Report untracked stores as unavailable and continue the audit. Use `add_keywords` only when the user separately authorizes tracking setup; empty rankings for an untracked store do not prove poor performance.
 
 3. **Extract competitor keywords**: Call `extract_competitors_keywords` with 3-5 top competitor app IDs to find keyword gaps. This is the highest-value Astro tool — it reveals keywords competitors rank for that you don't. Run this per store when possible.
 
@@ -190,7 +190,7 @@ Flag high-value combos in recommendations.
 
 - Astro MCP not connected → skip with note: "Connect Astro MCP for keyword gap analysis"
 - App not tracked in Astro → skip with note: "Add app to Astro with `mcp__astro__add_app` for gap analysis"
-- Store not tracked for a locale → add tracking with `add_keywords` before querying
+- Store not tracked for a locale → report the gap and skip its rankings; tracking setup requires separate authorization
 
 ## Output Format
 

--- a/skills/asc-aso-audit/references/aso_rules.md
+++ b/skills/asc-aso-audit/references/aso_rules.md
@@ -36,7 +36,7 @@ Rules enforced by the asc-aso-audit skill. Each rule links to the check that tes
 - **Localize keywords per market** — do not just translate your primary keywords. Research what users in each locale actually search for.
 - **English (US) keywords may carry into other English-speaking storefronts** but dedicated localization always outperforms.
 - **Identical keyword fields across locales** usually indicates untranslated/unlocalized metadata.
-- **Track keywords in each locale's store** — keyword popularity varies dramatically across territories. A keyword with 70 popularity in the US store may have 5 popularity in France. Use Astro `add_keywords` to set up tracking per store before analyzing.
+- **Track keywords in each locale's store** — keyword popularity varies dramatically across territories. A keyword with 70 popularity in the US store may have 5 popularity in France. Query existing Astro tracking; report and skip untracked stores during an audit. Use `add_keywords` only when tracking setup is explicitly authorized.
 - **Use competitor analysis per store** — top competitors differ by market. Run `extract_competitors_keywords` with locale-relevant competitor apps.
 
 ## Non-Latin Script Rules

--- a/skills/asc-release-flow/SKILL.md
+++ b/skills/asc-release-flow/SKILL.md
@@ -16,7 +16,9 @@ This skill owns:
 - submitting a prepared version;
 - assembling a multi-item review submission.
 
-Use [the preparation section](references/multi-item-submissions.md#prepare-every-item) for Game Center item preparation or attachment blockers. Use that reference's assembly and submission sections only after the app version is staged and the multi-item lane is selected. Stop and use `asc-submission-health` for other validation blockers, a stuck submission, cancellation, or retry decisions.
+Use [the preparation section](references/multi-item-submissions.md#prepare-every-item) for Game Center item preparation or attachment blockers. Use that reference's assembly and submission sections only after the app version is staged and the multi-item lane is selected. Switch to `asc-submission-health` for other validation blockers, a stuck submission, cancellation, or retry decisions.
+
+Switch skills within the current task, preserving resolved targets, authorization, and verified progress. A failing gate blocks dependent mutations, not diagnosis or independent authorized work. Continue authorized repairs and resume this flow; request new authority only when repairs exceed the agreed scope.
 
 ## Preconditions
 
@@ -57,7 +59,7 @@ Digital goods are a hard gate. If the release includes IAPs or subscriptions, st
 
 For Game Center items, complete only [Prepare every item](references/multi-item-submissions.md#prepare-every-item), then return to this flow. Do not assemble or submit the multi-item review submission during readiness.
 
-If app validation reports a Game Center item blocker, stop and use that preparation section. If the only blocker is an unattached build in the staging lane, continue to the staging section. For every other blocker, stop the release flow and use `asc-submission-health`. Do not bury unrelated remediation inside the release run.
+If app validation reports a Game Center item blocker, stop and use that preparation section. If the only blocker is an unattached build in the staging lane, continue to the staging section. For every other blocker, pause dependent release actions and use `asc-submission-health`; resume after authorized repairs pass validation.
 
 ## Stage an existing build
 
@@ -147,7 +149,7 @@ Report:
 
 - the app, version, platform, build, and submission IDs;
 - which lane ran and whether it completed;
-- every mutation confirmed by the user;
+- mutations performed under the user's authorization;
 - the exact command to monitor the resulting submission.
 
 Use `asc-submission-health` for monitoring, cancellation, rejection diagnosis, or retry decisions.

--- a/skills/asc-revenuecat-catalog-sync/SKILL.md
+++ b/skills/asc-revenuecat-catalog-sync/SKILL.md
@@ -47,7 +47,7 @@ Use this skill to keep App Store Connect (ASC) and RevenueCat aligned, including
    - missing in ASC
    - missing in RevenueCat
    - mapping conflicts (identifier/type/app mismatch)
-4. Present a plan and wait for confirmation.
+4. Present the plan. Audit-only requests finish with findings; apply requests require approval covering the complete current diff. Reuse prior approval if the refreshed diff is unchanged.
 
 ### 2) Apply mode (explicit)
 Execute approved actions in this order:
@@ -288,7 +288,7 @@ Failures:
 
 ## Agent behavior
 - Always run audit first, even in apply mode.
-- Ask for confirmation before create/update operations.
+- Reuse approval covering the complete current diff for its create/update operations. Ask again only when approval is absent or additional or materially changed actions fall outside it.
 - Match by `store_identifier` first.
 - Use full pagination (`--paginate` for ASC, `starting_after` for RevenueCat tools).
 - Continue processing after per-item failures and report all failures together.

--- a/skills/asc-submission-health/SKILL.md
+++ b/skills/asc-submission-health/SKILL.md
@@ -16,14 +16,14 @@ This skill owns:
 - review status and history;
 - cancellation and retry decisions.
 
-Do not stage, upload, publish, or submit a healthy release from this skill.
+Use `asc-release-flow` for staging, upload, publication, and submission. Switching skills continues the current task with its resolved targets, authorization, and verified progress; it does not require the user to restart the workflow. Continue authorized repairs and return to release execution when healthy. Ask for new authority only when a repair exceeds scope.
 
 ## Answer order
 
 1. State whether the version is ready, blocked, or already under review.
 2. Name each blocker and the evidence that proves it.
 3. Separate public-API repairs from web-session and manual work.
-4. Give one next command. Do not dump the entire repair catalog.
+4. Run the read-only checks needed to establish the diagnosis. For diagnosis-only requests, report the evidence and one proposed repair command without executing that repair. For authorized execution, continue the repair queue and report completed work and remaining blockers.
 
 ## Establish the target
 


### PR DESCRIPTION
ASC workflow instructions could request approval again for an unchanged catalog plan, hand an authorized release back to the user at a skill boundary, or mutate Astro tracking during an audit. Reuse approval covering the current diff, continue authorized release/health work in the same task, and report untracked territories without creating tracking. Read-only diagnosis still runs the checks needed to establish evidence.

Preserves explicit write authorization, product readiness gates, dry runs, destructive confirmations, and duplicate-submission checks. No command examples or plugin manifests changed.

Validation: all 25 skills passed `agentskills validate`; changed skill entrypoints passed the skill-creator validator; packaging validation, five packaging tests, and both strict Claude manifest validators passed. Final full-branch local Codex review found no actionable issues. Host installation checks remain covered by CI.
