### PR TITLE
docs: sync skills with asc 5.0.0

### DIFF
--- a/skills/asc-crash-triage/SKILL.md
+++ b/skills/asc-crash-triage/SKILL.md
@@ -18,7 +18,7 @@ Use this skill to fetch, analyze, and summarize TestFlight crash reports, beta f
 List recent crashes (newest first):
 
 - `asc testflight crashes list --app "APP_ID" --sort -createdDate --limit 10`
-- Filter by build: `asc testflight crashes list --app "APP_ID" --build "BUILD_ID" --sort -createdDate --limit 10`
+- Filter by build: `asc testflight crashes list --app "APP_ID" --build-id "BUILD_ID" --sort -createdDate --limit 10`
 - Filter by device/OS: `asc testflight crashes list --app "APP_ID" --device-model "iPhone16,2" --os-version "18.0"`
 - All crashes: `asc testflight crashes list --app "APP_ID" --paginate`
 - Table view: `asc testflight crashes list --app "APP_ID" --sort -createdDate --limit 10 --output table`
@@ -29,18 +29,18 @@ List recent feedback (newest first):
 
 - `asc testflight feedback list --app "APP_ID" --sort -createdDate --limit 10`
 - With screenshots: `asc testflight feedback list --app "APP_ID" --sort -createdDate --limit 10 --include-screenshots`
-- Filter by build: `asc testflight feedback list --app "APP_ID" --build "BUILD_ID" --sort -createdDate`
+- Filter by build: `asc testflight feedback list --app "APP_ID" --build-id "BUILD_ID" --sort -createdDate`
 - All feedback: `asc testflight feedback list --app "APP_ID" --paginate`
 
 ## Performance diagnostics (hangs, disk writes, launches)
 
 Requires a build ID. Resolve via `asc builds info --app "APP_ID" --latest --platform IOS` or `asc builds list --app "APP_ID" --sort -uploadedDate --limit 5`.
 
-- List diagnostic signatures: `asc performance diagnostics list --build "BUILD_ID"`
-- Filter by type: `asc performance diagnostics list --build "BUILD_ID" --diagnostic-type "HANGS"`
+- List diagnostic signatures: `asc performance diagnostics list --build-id "BUILD_ID"`
+- Filter by type: `asc performance diagnostics list --build-id "BUILD_ID" --diagnostic-type "HANGS"`
   - Types: `HANGS`, `DISK_WRITES`, `LAUNCHES`
 - View logs for a signature: `asc performance diagnostics view --id "SIGNATURE_ID"`
-- Download all metrics: `asc performance download --build "BUILD_ID" --output ./metrics.json`
+- Download all metrics: `asc performance download --build-id "BUILD_ID" --output ./metrics.json`
 
 ## Resolving IDs
 

--- a/skills/asc-release-flow/SKILL.md
+++ b/skills/asc-release-flow/SKILL.md
@@ -71,7 +71,7 @@ Preview metadata-driven staging:
 asc release stage \
   --app "APP_ID" \
   --version "1.2.3" \
-  --build "BUILD_ID" \
+  --build-id "BUILD_ID" \
   --metadata-dir "./metadata/version/1.2.3" \
   --dry-run \
   --output table
@@ -83,7 +83,7 @@ Apply the reviewed plan:
 asc release stage \
   --app "APP_ID" \
   --version "1.2.3" \
-  --build "BUILD_ID" \
+  --build-id "BUILD_ID" \
   --metadata-dir "./metadata/version/1.2.3" \
   --confirm
 ```
@@ -101,11 +101,11 @@ Structured output includes a `validate_build` step at the start of `steps[]`. Ma
 Use `asc review submit` after metadata, review details, availability, build processing, and product readiness are already resolved.
 
 ```bash
-asc review submit --app "APP_ID" --version "1.2.3" --build "BUILD_ID" --dry-run --output table
-asc review submit --app "APP_ID" --version "1.2.3" --build "BUILD_ID" --confirm
+asc review submit --app "APP_ID" --version "1.2.3" --build-id "BUILD_ID" --dry-run --output table
+asc review submit --app "APP_ID" --version "1.2.3" --build-id "BUILD_ID" --confirm
 ```
 
-Use `--version-id "VERSION_ID"` instead of `--version` when the exact version ID is known. `--build` may be omitted only when the intended build is already attached and verified.
+Use `--version-id "VERSION_ID"` instead of `--version` when the exact version ID is known. `--build-id` may be omitted only when the intended build is already attached and verified.
 
 ## Upload or build, then publish
 

--- a/skills/asc-signing-setup/SKILL.md
+++ b/skills/asc-signing-setup/SKILL.md
@@ -105,8 +105,8 @@ Notes:
   matching App Store Connect certificate. A multi-identity PKCS#12 also needs
   `--identity-sha256`.
 - Prefer `--password-file`; `ASC_SIGNING_SYNC_PASSWORD` is the non-file fallback.
-  `--password` and `ASC_MATCH_PASSWORD` are deprecated during 4.x and will be
-  rejected in 5.0.0.
+  `--password` and `ASC_MATCH_PASSWORD` were removed in 5.0.0 and are now
+  rejected.
 - Certificate/profile-only sync remains supported but reports
   `identityPresent: false`; it is not a usable signing identity by itself.
 - `pull` reports private identities in `sensitiveFiles` and writes them mode

--- a/skills/asc-submission-health/references/digital-goods.md
+++ b/skills/asc-submission-health/references/digital-goods.md
@@ -58,7 +58,7 @@ asc web review subscriptions attach \
 
 These commands require an authenticated Apple web session. If the user declines web-session automation, select the subscription manually in App Store Connect.
 
-Do not build new workflows around deprecated `asc subscriptions review submit`.
+`asc subscriptions review submit` was removed in 5.0.0; use the version-scoped submission flow.
 
 ## Prepare a subscription version
 
@@ -200,7 +200,7 @@ Upload a missing legacy review screenshot when diagnostics request one:
 asc iap review-screenshots create --iap-id "IAP_ID" --file "./review.png"
 ```
 
-Do not build new workflows around deprecated `asc iap submit`.
+`asc iap submit` was removed in 5.0.0; use the version-scoped submission flow.
 
 Resolve a version-scoped IAP:
 

--- a/skills/asc-submission-health/references/readiness-repairs.md
+++ b/skills/asc-submission-health/references/readiness-repairs.md
@@ -41,7 +41,7 @@ asc encryption declarations create \
 Assign the declaration to the resolved build:
 
 ```bash
-asc encryption declarations assign-builds --id "DECLARATION_ID" --build "BUILD_ID"
+asc encryption declarations assign-builds --id "DECLARATION_ID" --build-id "BUILD_ID"
 ```
 
 If the app truly uses only exempt transport encryption, update the local plist and rebuild instead of making a false declaration:

--- a/skills/asc-testflight-orchestration/SKILL.md
+++ b/skills/asc-testflight-orchestration/SKILL.md
@@ -33,7 +33,7 @@ Use this skill when managing TestFlight testers, groups, and build distribution.
 ## Upload without distribution
 - `asc publish testflight --app "APP_ID" --ipa "./app.ipa" --upload-only --output json`
 - Add `--wait` when the next step needs a processed build.
-- Upload-only requires a new IPA or local Xcode build. Do not combine it with an existing `--build`, groups, tester notifications, test notes, or beta-review submission. `--build-number` is allowed as upload metadata, but it cannot be the only build input.
+- Upload-only requires a new IPA or local Xcode build. Do not combine it with an existing `--build-id`, groups, tester notifications, test notes, or beta-review submission. `--build-number` is allowed as upload metadata, but it cannot be the only build input.
 
 ## What to Test notes
 - `asc builds test-notes create --build-id "BUILD_ID" --locale "en-US" --whats-new "Test instructions"`

--- a/skills/asc-workflow/SKILL.md
+++ b/skills/asc-workflow/SKILL.md
@@ -187,12 +187,12 @@ Add `"if": "VAR_NAME"` to a step. Truthy values are `1`, `true`, `yes`, `y`, and
         },
         {
           "name": "stage",
-          "run": "asc release stage --app $APP_ID --version $VERSION --build $BUILD_ID --metadata-dir ./metadata/version/$VERSION --confirm --output json"
+          "run": "asc release stage --app $APP_ID --version $VERSION --build-id $BUILD_ID --metadata-dir ./metadata/version/$VERSION --confirm --output json"
         },
         {
           "name": "submit",
           "if": "SUBMIT_FOR_REVIEW",
-          "run": "asc review submit --app $APP_ID --version $VERSION --build $BUILD_ID --confirm --output json"
+          "run": "asc review submit --app $APP_ID --version $VERSION --build-id $BUILD_ID --confirm --output json"
         }
       ]
     },


### PR DESCRIPTION
asc 5.0.0 closes the 4.x deprecation window. The removed surfaces are still documented in the skills, and 5.0.0 exits 2 on an unknown flag or command instead of warning — so these examples now fail outright rather than degrade.

## Changes

- **`--build` → `--build-id`** — 12 sites across `release stage`, `review submit`, `testflight crashes list`, `testflight feedback list`, `performance diagnostics list`, `performance download`, `encryption declarations assign-builds`, and the two workflow JSON `run` strings.
- **`--password` / `ASC_MATCH_PASSWORD`** — described as "deprecated during 4.x and will be rejected in 5.0.0"; they are removed now. The surrounding examples already use `--password-file`, so only the note changed.
- **`asc subscriptions review submit` and `asc iap submit`** — described as deprecated; both are gone. Now point at the version-scoped submission flow.

## Verification

Extracted every `asc` invocation in `skills/` and checked each subcommand path and flag against 5.0.0's own `--help` output.

| | before | after |
|---|---|---|
| invocations parsed | 775 | 775 |
| accepted | 746 | 758 |
| flagged | 29 | 17 |

The 17 remaining are prose, not commands — skill titles like "asc crash triage" and "asc cli usage" that the extractor picks up. No unknown command or unknown flag survives in a real invocation.

`scripts/validate-plugin-packaging.py` passes (25 skills, Codex asc, Claude asc, version 1.0.0).

Not touched: `--bundle` in `bundle-ids capabilities list` (still correct in 5.0 — `--bundle-id` was the removed alias), and the four new 5.0 hard-error pairings (`auth logout --confirm`, Game Center `--confirm`, `signing --device`/`--create-missing`, app-scoped `--build-number`/`--platform`), none of which any skill triggers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)