### PR TITLE
fix(skills): sync build selectors and removed-command notes with asc 5.x

### DIFF
--- a/skills/asc-crash-triage/SKILL.md
+++ b/skills/asc-crash-triage/SKILL.md
@@ -18,7 +18,7 @@ Use this skill to fetch, analyze, and summarize TestFlight crash reports, beta f
 List recent crashes (newest first):
 
 - `asc testflight crashes list --app "APP_ID" --sort -createdDate --limit 10`
-- Filter by build: `asc testflight crashes list --app "APP_ID" --build "BUILD_ID" --sort -createdDate --limit 10`
+- Filter by build: `asc testflight crashes list --app "APP_ID" --build-id "BUILD_ID" --sort -createdDate --limit 10`
 - Filter by device/OS: `asc testflight crashes list --app "APP_ID" --device-model "iPhone16,2" --os-version "18.0"`
 - All crashes: `asc testflight crashes list --app "APP_ID" --paginate`
 - Table view: `asc testflight crashes list --app "APP_ID" --sort -createdDate --limit 10 --output table`
@@ -29,18 +29,18 @@ List recent feedback (newest first):
 
 - `asc testflight feedback list --app "APP_ID" --sort -createdDate --limit 10`
 - With screenshots: `asc testflight feedback list --app "APP_ID" --sort -createdDate --limit 10 --include-screenshots`
-- Filter by build: `asc testflight feedback list --app "APP_ID" --build "BUILD_ID" --sort -createdDate`
+- Filter by build: `asc testflight feedback list --app "APP_ID" --build-id "BUILD_ID" --sort -createdDate`
 - All feedback: `asc testflight feedback list --app "APP_ID" --paginate`
 
 ## Performance diagnostics (hangs, disk writes, launches)
 
 Requires a build ID. Resolve via `asc builds info --app "APP_ID" --latest --platform IOS` or `asc builds list --app "APP_ID" --sort -uploadedDate --limit 5`.
 
-- List diagnostic signatures: `asc performance diagnostics list --build "BUILD_ID"`
-- Filter by type: `asc performance diagnostics list --build "BUILD_ID" --diagnostic-type "HANGS"`
+- List diagnostic signatures: `asc performance diagnostics list --build-id "BUILD_ID"`
+- Filter by type: `asc performance diagnostics list --build-id "BUILD_ID" --diagnostic-type "HANGS"`
   - Types: `HANGS`, `DISK_WRITES`, `LAUNCHES`
 - View logs for a signature: `asc performance diagnostics view --id "SIGNATURE_ID"`
-- Download all metrics: `asc performance download --build "BUILD_ID" --output ./metrics.json`
+- Download all metrics: `asc performance download --build-id "BUILD_ID" --output ./metrics.json`
 
 ## Resolving IDs
 

--- a/skills/asc-release-flow/SKILL.md
+++ b/skills/asc-release-flow/SKILL.md
@@ -71,7 +71,7 @@ Preview metadata-driven staging:
 asc release stage \
   --app "APP_ID" \
   --version "1.2.3" \
-  --build "BUILD_ID" \
+  --build-id "BUILD_ID" \
   --metadata-dir "./metadata/version/1.2.3" \
   --dry-run \
   --output table
@@ -83,7 +83,7 @@ Apply the reviewed plan:
 asc release stage \
   --app "APP_ID" \
   --version "1.2.3" \
-  --build "BUILD_ID" \
+  --build-id "BUILD_ID" \
   --metadata-dir "./metadata/version/1.2.3" \
   --confirm
 ```
@@ -101,11 +101,11 @@ Structured output includes a `validate_build` step at the start of `steps[]`. Ma
 Use `asc review submit` after metadata, review details, availability, build processing, and product readiness are already resolved.
 
 ```bash
-asc review submit --app "APP_ID" --version "1.2.3" --build "BUILD_ID" --dry-run --output table
-asc review submit --app "APP_ID" --version "1.2.3" --build "BUILD_ID" --confirm
+asc review submit --app "APP_ID" --version "1.2.3" --build-id "BUILD_ID" --dry-run --output table
+asc review submit --app "APP_ID" --version "1.2.3" --build-id "BUILD_ID" --confirm
 ```
 
-Use `--version-id "VERSION_ID"` instead of `--version` when the exact version ID is known. `--build` may be omitted only when the intended build is already attached and verified.
+Use `--version-id "VERSION_ID"` instead of `--version` when the exact version ID is known. `--build-id` may be omitted only when the intended build is already attached and verified.
 
 ## Upload or build, then publish
 

--- a/skills/asc-signing-setup/SKILL.md
+++ b/skills/asc-signing-setup/SKILL.md
@@ -105,8 +105,8 @@ Notes:
   matching App Store Connect certificate. A multi-identity PKCS#12 also needs
   `--identity-sha256`.
 - Prefer `--password-file`; `ASC_SIGNING_SYNC_PASSWORD` is the non-file fallback.
-  `--password` and `ASC_MATCH_PASSWORD` are deprecated during 4.x and will be
-  rejected in 5.0.0.
+  `--password` and `ASC_MATCH_PASSWORD` were removed in 5.0.0 and are
+  rejected.
 - Certificate/profile-only sync remains supported but reports
   `identityPresent: false`; it is not a usable signing identity by itself.
 - `pull` reports private identities in `sensitiveFiles` and writes them mode

--- a/skills/asc-submission-health/references/digital-goods.md
+++ b/skills/asc-submission-health/references/digital-goods.md
@@ -58,7 +58,7 @@ asc web review subscriptions attach \
 
 These commands require an authenticated Apple web session. If the user declines web-session automation, select the subscription manually in App Store Connect.
 
-Do not build new workflows around deprecated `asc subscriptions review submit`.
+Do not build workflows around `asc subscriptions review submit`; it was removed in 5.0.0.
 
 ## Prepare a subscription version
 
@@ -200,7 +200,7 @@ Upload a missing legacy review screenshot when diagnostics request one:
 asc iap review-screenshots create --iap-id "IAP_ID" --file "./review.png"
 ```
 
-Do not build new workflows around deprecated `asc iap submit`.
+Do not build workflows around `asc iap submit`; it was removed in 5.0.0.
 
 Resolve a version-scoped IAP:
 

--- a/skills/asc-submission-health/references/readiness-repairs.md
+++ b/skills/asc-submission-health/references/readiness-repairs.md
@@ -41,7 +41,7 @@ asc encryption declarations create \
 Assign the declaration to the resolved build:
 
 ```bash
-asc encryption declarations assign-builds --id "DECLARATION_ID" --build "BUILD_ID"
+asc encryption declarations assign-builds --id "DECLARATION_ID" --build-id "BUILD_ID"
 ```
 
 If the app truly uses only exempt transport encryption, update the local plist and rebuild instead of making a false declaration:

--- a/skills/asc-testflight-orchestration/SKILL.md
+++ b/skills/asc-testflight-orchestration/SKILL.md
@@ -33,7 +33,7 @@ Use this skill when managing TestFlight testers, groups, and build distribution.
 ## Upload without distribution
 - `asc publish testflight --app "APP_ID" --ipa "./app.ipa" --upload-only --output json`
 - Add `--wait` when the next step needs a processed build.
-- Upload-only requires a new IPA or local Xcode build. Do not combine it with an existing `--build`, groups, tester notifications, test notes, or beta-review submission. `--build-number` is allowed as upload metadata, but it cannot be the only build input.
+- Upload-only requires a new IPA or local Xcode build. Do not combine it with an existing `--build-id`, groups, tester notifications, test notes, or beta-review submission. `--build-number` is allowed as upload metadata, but it cannot be the only build input.
 
 ## What to Test notes
 - `asc builds test-notes create --build-id "BUILD_ID" --locale "en-US" --whats-new "Test instructions"`

--- a/skills/asc-workflow/SKILL.md
+++ b/skills/asc-workflow/SKILL.md
@@ -187,12 +187,12 @@ Add `"if": "VAR_NAME"` to a step. Truthy values are `1`, `true`, `yes`, `y`, and
         },
         {
           "name": "stage",
-          "run": "asc release stage --app $APP_ID --version $VERSION --build $BUILD_ID --metadata-dir ./metadata/version/$VERSION --confirm --output json"
+          "run": "asc release stage --app $APP_ID --version $VERSION --build-id $BUILD_ID --metadata-dir ./metadata/version/$VERSION --confirm --output json"
         },
         {
           "name": "submit",
           "if": "SUBMIT_FOR_REVIEW",
-          "run": "asc review submit --app $APP_ID --version $VERSION --build $BUILD_ID --confirm --output json"
+          "run": "asc review submit --app $APP_ID --version $VERSION --build-id $BUILD_ID --confirm --output json"
         }
       ]
     },


### PR DESCRIPTION
## Summary

Sync skill examples with the asc 5.x CLI surface. Every fix below is a `--build` build selector or removed-command reference that asc 5.0.0 rejects; the flag/command was dropped in 5.0.0 (see `migrate-to-5-0.mdx` in the CLI repo). Telemetry from the first week of 5.x still shows agents issuing `review submit --build`, `release stage --build`, and similar removed forms, so these examples are being copied verbatim.

Evidence source: App-Store-Connect-CLI `origin/main` at `78d90da1e` (tag `5.3.0` is the latest release), built locally and queried with `ASC_BYPASS_KEYCHAIN=1 asc <cmd> --help`.

## Fixes

| File | Change | CLI help evidence (FLAGS section) |
| --- | --- | --- |
| `skills/asc-release-flow/SKILL.md` | `asc release stage --build` -> `--build-id` (2 examples) and the prose note about omitting the flag | `asc release stage --help`: `--build-id  Build ID to attach (required)`; runtime: `Error: unknown flag --build for asc release stage` |
| `skills/asc-release-flow/SKILL.md` | `asc review submit --build` -> `--build-id` (2 examples) | `asc review submit --help`: `--build-id  Build ID to attach` |
| `skills/asc-workflow/SKILL.md` | `.asc/workflow.json` sample steps: `release stage --build $BUILD_ID` and `review submit --build $BUILD_ID` -> `--build-id` | same as above |
| `skills/asc-crash-triage/SKILL.md` | `asc testflight crashes list --build` -> `--build-id` | `asc testflight crashes list --help`: `--build-id  Filter by build ID(s), comma-separated` |
| `skills/asc-crash-triage/SKILL.md` | `asc testflight feedback list --build` -> `--build-id` | `asc testflight feedback list --help`: `--build-id  Filter by build ID(s), comma-separated` |
| `skills/asc-crash-triage/SKILL.md` | `asc performance diagnostics list --build` -> `--build-id` (2 examples) | `asc performance diagnostics list --help`: `--build-id  Build ID to list diagnostics for` |
| `skills/asc-crash-triage/SKILL.md` | `asc performance download --build` -> `--build-id` | `asc performance download --help`: `--build-id  Build ID to download metrics for` |
| `skills/asc-submission-health/references/readiness-repairs.md` | `asc encryption declarations assign-builds --build` -> `--build-id` | `asc encryption declarations assign-builds --help`: `--build-id  Build IDs to assign (comma-separated)` |
| `skills/asc-testflight-orchestration/SKILL.md` | upload-only prose: existing `--build` -> `--build-id` | `asc publish testflight --help`: `--build-id  Existing build ID to distribute (skip upload)` |
| `skills/asc-signing-setup/SKILL.md` | `--password` / `ASC_MATCH_PASSWORD` described as "deprecated during 4.x, rejected in 5.0.0" -> "removed in 5.0.0 and rejected" | `asc signing sync push --help` lists only `--password-file` and `--identity-password-file`; runtime: `Error: unknown flag --password for asc signing sync push` |
| `skills/asc-submission-health/references/digital-goods.md` | `asc subscriptions review submit` and `asc iap submit` described as "deprecated" -> "removed in 5.0.0" | runtime: `Error: unknown command asc subscriptions review submit` / `Error: unknown command asc iap submit` |

## Verification

- Extracted all 753 `asc ...` invocations across `skills/` (code blocks, inline code, `\`-continued lines) and checked each command path against the CLI's subcommand listing and each long flag against the command's `FLAGS` section. After this change: 0 unknown flags, 0 unknown commands (remaining hits are skill titles like "asc build lifecycle", plus the two "removed" notes above that intentionally name a non-existent command).
- Cross-checked every `ASC_*` env var named in `skills/` against the CLI source; the only non-CLI name (`ASC_ANALYTICS_DIR`) is a shell variable defined by the skill itself.
- Removed-alias sweep from `migrate-to-5-0.mdx` (`--version-id` on localizations, `--group-id` on testflight groups view, `--subscription-id` on subscriptions view, `--app` on apps view, `--id` on versions view, `--newest`, `--app-id`, `--external-testing`, `--version-limit`, `--image-limit`, `--price-id`, `--two-factor-code`, `--keyword`, `ASC_IRIS_*`, `--territory ALL`): no remaining occurrences in a removed position; the remaining `--version-id` / `--group-id` / `--subscription-id` / `--bundle-id` / `--localization-id` / `--available-in-new-territories` usages are on commands where the CLI help still lists those flags.
- `python scripts/validate-plugin-packaging.py . --expected-skills 25`: passed.
- `python -m unittest discover -s tests -p 'test_*.py'`: OK.
- `agentskills validate` (skills-ref 0.1.1, the CI pin) on all 25 skills: passed.
- Not executed: no live App Store Connect calls; every example was validated against `--help` and the runtime flag/command parser only.

## Not changed

`asc install-skills` in the CLI repo pins this pack at `f52c4f04323bb2dfb21ca8be82e6494e9cd0b4d8` (2026-09-05, one day before the 5.0.0 tag), so the installed pack ships the same stale examples until the pin is refreshed to include this change. That bump is a separate CLI-repo follow-up.
